### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ author=Ben Combee, Ran Talbott, Christopher Lee, Martin Lormes, Francisco M Cuen
 maintainer=Kasper Kamperman <kasperkamperman@gmail.com>
 sentence=Arduino WebDuino http-server/webserver ported to Particle.
 paragraph=See documentation on Github.
-category=WebServer
+category=Communication
 url=https://github.com/kasperkamperman/webduino
 repository=https://github.com/kasperkamperman/Webduino.git


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'WebServer' in library WebDuino is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format